### PR TITLE
Bump pipeline from 1.37.2 to 1.37.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (c) The Amphitheatre Authors. All rights reserved.
+# Copyright 2018-2020 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 bin/
+linux/
 dependencies/
 package/
 scratch/
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,29 +1,19 @@
 #!/usr/bin/env bash
-# Copyright (c) The Amphitheatre Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -euo pipefail
 
-GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/amp-buildpacks/hardhat/cmd/main
+GOMOD=$(head -1 go.mod | awk '{print $2}')
+GOOS="linux" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then
-  strip bin/main
+  strip linux/amd64/bin/main linux/arm64/bin/main
 fi
 
 if [ "${COMPRESS:-none}" != "none" ]; then
-  $COMPRESS bin/main
+  $COMPRESS linux/amd64/bin/main linux/arm64/bin/main
 fi
 
-ln -fs main bin/build
-ln -fs main bin/detect
+ln -fs main linux/amd64/bin/build
+ln -fs main linux/arm64/bin/build
+ln -fs main linux/amd64/bin/detect
+ln -fs main linux/arm64/bin/detect


### PR DESCRIPTION
Bumps pipeline from `1.37.2` to `1.37.2`.

<details>
<summary>Release Notes</summary>
<h1 dir="auto">❤️The road to ARM64🌈</h1>
<h2 dir="auto">⭐️ Enhancements</h2>
<ul dir="auto">
<li>Fix package test (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2209382905" data-permission-text="Title is private" data-url="https://github.com/paketo-buildpacks/pipeline-builder/issues/1540" data-hovercard-type="pull_request" data-hovercard-url="/paketo-buildpacks/pipeline-builder/pull/1540/hovercard" href="https://github.com/paketo-buildpacks/pipeline-builder/pull/1540">#1540</a>) <a class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anthonydahanne/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/anthonydahanne">@anthonydahanne</a></li>
</ul>
</details>